### PR TITLE
rewritten compute_coverage function for paired ends

### DIFF
--- a/src/alignment.jl
+++ b/src/alignment.jl
@@ -1,7 +1,7 @@
 #!/usr/bin/env julia
 """
     Wrapper function for kraken2 taxonomic sequence classifier that assigns taxonomic labels to DNA sequences.
-    
+
     # Output
     *.results.txt is a five fields tab-delimited text file.
     *.report.txt is in kraken2's modified report format (--report-minimizer-data).
@@ -33,7 +33,7 @@ function align_kraken2(
 end
 
 """
-    Core dispatch of align_mem, which is a wrapper for bwa-mem2. Takes ´in_file1´ and ´in_file2´ and ´genome_file´ and builds a shell 
+    Core dispatch of align_mem, which is a wrapper for bwa-mem2. Takes ´in_file1´ and ´in_file2´ and ´genome_file´ and builds a shell
     command that runs bwa-mem2 with the specified additional parameters and writes the resulting alignments in bam format into ´out_file´.
 
     # Arguments
@@ -76,14 +76,14 @@ end
 align_mem(in_file::String, out_file::String, genome_file::String;
     min_score=30, match=1, mismatch=4, gap_open=6, gap_extend=1, clipping_penalty=5, min_seed_len=19, reseeding_factor=1.5, bwa_bin="bwa-mem2", sam_bin="samtools") =
     align_mem(in_file, nothing, out_file::String, genome_file::String;
-        min_score=min_score, match=match, mismatch=mismatch, gap_open=gap_open, gap_extend=gap_extend, clipping_penalty=clipping_penalty, min_seed_len=min_seed_len, 
+        min_score=min_score, match=match, mismatch=mismatch, gap_open=gap_open, gap_extend=gap_extend, clipping_penalty=clipping_penalty, min_seed_len=min_seed_len,
         reseeding_factor=reseeding_factor, bwa_bin=bwa_bin, sam_bin=sam_bin)
 
 """
-    Helper dispatch of align_mem, which is a wrapper for bwa-mem2. Runs align_mem on `read_files::T` 
-    where T is a FileCollection and aligns it against `genome::Genome`. This enables easy handling of 
+    Helper dispatch of align_mem, which is a wrapper for bwa-mem2. Runs align_mem on `read_files::T`
+    where T is a FileCollection and aligns it against `genome::Genome`. This enables easy handling of
     whole folders containing sequence files and the manipulation of a genome using Genome.
-"""   
+"""
 function align_mem(read_files::T, genome::Genome; min_score=30, match=1, mismatch=4, gap_open=6, gap_extend=1, clipping_penalty=5, unpair_penalty=9, reseeding_factor=1.5,
                     min_seed_len=19, unpair_rescue=false, bwa_bin="bwa-mem2", sam_bin="samtools", overwrite_existing=false) where {T<:FileCollection}
     tmp_genome = tempname()
@@ -96,11 +96,11 @@ function align_mem(read_files::T, genome::Genome; min_score=30, match=1, mismatc
         isa(read_files, SingleTypeFiles) ?
         align_mem(file, out_file, tmp_genome;
                 min_score=min_score, match=match, mismatch=mismatch, gap_open=gap_open,
-                gap_extend=gap_extend, clipping_penalty=clipping_penalty,  min_seed_len=min_seed_len, 
+                gap_extend=gap_extend, clipping_penalty=clipping_penalty,  min_seed_len=min_seed_len,
                 reseeding_factor=reseeding_factor, bwa_bin=bwa_bin, sam_bin=sam_bin) :
         align_mem(first(file), last(file), out_file, tmp_genome;
                 min_score=min_score, match=match, mismatch=mismatch, gap_open=gap_open, gap_extend=gap_extend,
-                clipping_penalty=clipping_penalty, unpair_penalty=unpair_penalty, unpair_rescue=unpair_rescue, 
+                clipping_penalty=clipping_penalty, unpair_penalty=unpair_penalty, unpair_rescue=unpair_rescue,
                 min_seed_len=min_seed_len, reseeding_factor=reseeding_factor, bwa_bin=bwa_bin, sam_bin=sam_bin)
     end
     rm(tmp_genome)
@@ -111,12 +111,12 @@ function align_mem(read_files::T, genome::Genome; min_score=30, match=1, mismatc
 end
 
 """
-    Helper dispatch of align_mem, which is a wrapper for bwa-mem2. Runs align_mem on `reads::T` where T 
-    is a SequenceContainer and aligns it against `genomes::Vector{Genome}`. This enables easy handling 
+    Helper dispatch of align_mem, which is a wrapper for bwa-mem2. Runs align_mem on `reads::T` where T
+    is a SequenceContainer and aligns it against `genomes::Vector{Genome}`. This enables easy handling
     of Sequences and their alignment against multiple genomes.
-"""  
+"""
 function align_mem(reads::T, genomes::Vector{Genome}, out_file::String; min_score=30, match=1, mismatch=4, gap_open=6, gap_extend=1, clipping_penalty=5,
-                unpair_penalty=9, unpair_rescue=false, min_seed_len=19, reseeding_factor=1.5, bwa_bin="bwa-mem2", sam_bin="samtools", 
+                unpair_penalty=9, unpair_rescue=false, min_seed_len=19, reseeding_factor=1.5, bwa_bin="bwa-mem2", sam_bin="samtools",
                 overwrite_existing=false) where T<:SequenceContainer
     (isfile(out_file) && !overwrite_existing) && return
     tmp_reads = tempname()
@@ -131,11 +131,11 @@ function align_mem(reads::T, genomes::Vector{Genome}, out_file::String; min_scor
         isa(reads, Sequences) ?
         align_mem(tmp_reads, this_out_file, tmp_genome;
             min_score=min_score, match=match, mismatch=mismatch, gap_open=gap_open, gap_extend=gap_extend,
-            clipping_penalty=clipping_penalty, min_seed_len=min_seed_len, reseeding_factor=reseeding_factor, 
+            clipping_penalty=clipping_penalty, min_seed_len=min_seed_len, reseeding_factor=reseeding_factor,
             bwa_bin=bwa_bin, sam_bin=sam_bin) :
         align_mem(tmp_reads, tmp_reads2, this_out_file, tmp_genome;
             min_score=min_score, match=match, mismatch=mismatch, gap_open=gap_open, gap_extend=gap_extend,
-            clipping_penalty=clipping_penalty, unpair_penalty=unpair_penalty, unpair_rescue=unpair_rescue, 
+            clipping_penalty=clipping_penalty, unpair_penalty=unpair_penalty, unpair_rescue=unpair_rescue,
             min_seed_len=min_seed_len, reseeding_factor=reseeding_factor, bwa_bin=bwa_bin, sam_bin=sam_bin)
 
         rm(tmp_genome)
@@ -174,7 +174,7 @@ struct AlignedPart
 end
 
 """
-    Helper function to extract start and stop of the alignment on the read from 
+    Helper function to extract start and stop of the alignment on the read from
     a cigar string. Also compute the stop position on the reference and the complete length of the read.
 """
 function readpositions(cigar::AbstractString)
@@ -209,8 +209,8 @@ function readpositions(cigar::AbstractString)
 end
 
 """
-    Helper function to extract start and stop of the alignment on the read from 
-    a XAM.BAM record. Also compute the stop position on the reference and the 
+    Helper function to extract start and stop of the alignment on the read from
+    a XAM.BAM record. Also compute the stop position on the reference and the
     complete length of the read.
 """
 function readpositions(record::BAM.Record)
@@ -535,7 +535,7 @@ function read_bam!(reads::Dict{T, AlignedRead}, bam_file::String; min_templength
         if !foundit
             readstart, readstop, _, readlen = readpositions(record)
             seq_interval = BAM.ispositivestrand(record) ? (readstart:readstop) : (readlen-readstop+1:readlen-readstart+1)
-            ref_interval = Interval(BAM.refname(record), BAM.leftposition(record), BAM.rightposition(record), BAM.ispositivestrand(record) == !invert ? Strand('+') : Strand('-'), AlignmentAnnotation())
+            ref_interval = Interval(BAM.refname(record), BAM.leftposition(record), BAM.rightposition(record), BAM.ispositivestrand(record) == !check_invert ? Strand('+') : Strand('-'), AlignmentAnnotation())
             alnpart = AlignedPart(ref_interval, seq_interval, nms, current_read)
         end
         id in keys(reads) ? push!(reads[id].alns, alnpart; reverse_order=reverse_order) : push!(reads, id=>AlignedRead([alnpart]))
@@ -641,3 +641,4 @@ function annotate!(features::Features, feature_alignments::Alignments{String}; k
 end
 
 function Coverage(alignments::Alignments)
+end

--- a/src/coverage.jl
+++ b/src/coverage.jl
@@ -64,19 +64,6 @@ function compute_coverage(files::SingleTypeFiles; norm=1000000, unique_mappings_
     return PairedSingleTypeFiles(bw_files, ".bw", "_forward", "_reverse")
 end
 
-function compute_coverage(files::PairedSingleTypeFiles; norm=1000000, unique_mappings_only=true, overwrite_existing=false, invert=:none)
-    @assert files.type == ".bam"
-    bw_files = Vector{Tuple{String, String}}()
-    for file in files
-        filename_f = file[1:end-4] * "_forward.bw"
-        filename_r = file[1:end-4] * "_reverse.bw"
-        push!(bw_files, (filename_f, filename_r))
-        (!overwrite_existing && isfile(filename_f) && isfile(filename_r)) && continue
-        compute_coverage(file; norm=norm, unique_mappings_only=unique_mappings_only, invert=invert)
-    end
-    return PairedSingleTypeFiles(bw_files, ".bw", "_forward", "_reverse")
-end
-
 struct Coverage <: AnnotationContainer
     list::IntervalCollection{Float64}
     chroms::Vector{Tuple{String, Int}}

--- a/src/coverage.jl
+++ b/src/coverage.jl
@@ -123,7 +123,7 @@ function Coverage(values_f::CoverageValues, values_r::CoverageValues, chroms::Ve
                 current_end += 1
                 current_end == current_len && break
             end
-            (current_pos == 1 && current_end == current_len) || push!(new_intervals, Interval(current_ref, current_pos, current_end, 
+            (current_pos == 1 && current_end == current_len) || push!(new_intervals, Interval(current_ref, current_pos, current_end,
                                                                     vals===values_f ? STRAND_POS : STRAND_NEG, current_value))
             current_pos = current_end + 1
             current_end = current_pos
@@ -148,7 +148,7 @@ function Base.write(filename_f::String, filename_r::String, coverage::Coverage)
     writer_f = BigWig.Writer(open(filename_f, "w"), chromosome_list)
     writer_r = BigWig.Writer(open(filename_r, "w"), chromosome_list)
     for interval in coverage
-        strand(interval) == STRAND_POS ? 
+        strand(interval) == STRAND_POS ?
         write(writer_f, (interval.seqname, interval.first, interval.last, interval.metadata)) :
         write(writer_r, (interval.seqname, interval.first, interval.last, interval.metadata))
     end
@@ -185,7 +185,7 @@ function Base.merge(coverages::Coverage ...)
     vals_r = Dict(chr=>zeros(Float64, len) for (chr,len) in coverages[1].chroms)
     for cv in coverages
         for interval in cv
-            strand(interval) == STRAND_POS ? 
+            strand(interval) == STRAND_POS ?
             vals_f[refname(interval)][leftposition(interval):rightposition(interval)] .+= interval.metadata/n :
             vals_r[refname(interval)][leftposition(interval):rightposition(interval)] .+= interval.metadata/n
         end
@@ -250,7 +250,7 @@ function tsss(notex::Coverage, tex::Coverage; min_tex_ratio=1.3, min_step=10, mi
 end
 
 function terms(coverage::Coverage; min_step=10, window_size=10, min_background_ratio=1.2)
-    min_background_increase = min_background_ratio - 1.0 
+    min_background_increase = min_background_ratio - 1.0
     vals = values(coverage)
     intervals = Vector{Interval{Float64}}()
     chrs = [chr[1] for chr in coverage.chroms]
@@ -269,4 +269,3 @@ function terms(coverage::Coverage; min_step=10, window_size=10, min_background_r
     end
     return Coverage(IntervalCollection(intervals, true), coverage.chroms)
 end
-

--- a/src/coverage.jl
+++ b/src/coverage.jl
@@ -24,10 +24,8 @@ function compute_coverage(bam_file::String; norm = 0, only_unique = true, invert
     vals_f = CoverageValues(chr=>zeros(Float64, len) for (chr, len) in chromosome_list)
     vals_r = CoverageValues(chr=>zeros(Float64, len) for (chr, len) in chromosome_list)
     count = 0
-    chim_count = 0
     for alignment in Alignments(bam_file; only_unique = only_unique, invert = invert)
         if ischimeric(alignment; check_annotation = false, min_distance = 3000)
-            chim_count += 1
             continue
         end
         ref = refname(alignment[1])
@@ -51,7 +49,6 @@ function compute_coverage(bam_file::String; norm = 0, only_unique = true, invert
     end
     close(writer_f)
     close(writer_r)
-    println("is chimeric count: ", chim_count)
 end
 
 function compute_coverage(files::SingleTypeFiles; norm=1000000, unique_mappings_only=true, overwrite_existing=false, invert=:none)

--- a/src/sequence.jl
+++ b/src/sequence.jl
@@ -108,12 +108,12 @@ end
 Base.length(reads::PairedSequences) = length(reads.dict)
 Base.keys(reads::PairedSequences) = keys(reads.dict)
 Base.values(reads::PairedSequences) = values(reads.dict)
-function Base.iterate(reads::PairedSequences) 
+function Base.iterate(reads::PairedSequences)
     it = iterate(reads.dict)
     isnothing(it) ? (return nothing) : ((key, (read1, read2)), state) = it
     return ((read1, read2), state)
 end
-function Base.iterate(reads::PairedSequences, state::Int) 
+function Base.iterate(reads::PairedSequences, state::Int)
     it = iterate(reads.dict, state)
     isnothing(it) ? (return nothing) : ((key, (read1, read2)), state) = it
     return ((read1, read2), state)
@@ -146,12 +146,12 @@ end
 Base.length(reads::Sequences) = length(reads.dict)
 Base.keys(reads::Sequences) = keys(reads.dict)
 Base.values(reads::Sequences) = values(reads.dict)
-function Base.iterate(reads::Sequences) 
+function Base.iterate(reads::Sequences)
     it = iterate(reads.dict)
     isnothing(it) ? (return nothing) : ((key, read), state) = it
     return (read, state)
 end
-function Base.iterate(reads::Sequences, state::Int) 
+function Base.iterate(reads::Sequences, state::Int)
     it = iterate(reads.dict, state)
     isnothing(it) ? (return nothing) : ((key, read), state) = it
     return (read, state)
@@ -176,7 +176,7 @@ function Sequences(f, paired_reads::PairedSequences{T}; use_when_tied=:none) whe
     @assert use_when_tied in [:none, :read1, :read2]
     reads = Dict{T, LongDNASeq}()
     for (key, (read1, read2)) in paired_reads
-        if use_when_tied == :read1 
+        if use_when_tied == :read1
             f(read1) ? push!(reads, key=>copy(read1)) : (f(read2) && push!(reads, key=>copy(read2)))
         elseif use_when_tied == :read2
             f(read2) ? push!(reads, key=>copy(read2)) : (f(read1) && push!(reads, key=>copy(read1)))
@@ -203,7 +203,7 @@ function read_reads(file::String; nb_reads=nothing, hash_id=true)
     read_counter = 0
     while !eof(reader)
         read!(reader, record)
-        id = !hash_id ? identifier(record) : 
+        id = !hash_id ? identifier(record) :
                 (is_bitstring ? parse(UInt, identifier(record); base=2) : hash(record.data[record.identifier]))
         push!(reads, id => LongDNASeq(record.data[record.sequence]))
         read_counter += 1
@@ -233,7 +233,7 @@ end
 #    is_zipped = endswith(files.type, ".gz")
 #    record = is_fastq ? FASTQ.Record() : FASTA.Record()
 #    sequencer = is_fastq ? FASTQ.sequence : FASTA.sequence
-#    
+#
 #    for file in files
 #        outfile = file * ".tmp"
 #        f = is_zipped ? GzipDecompressorStream(open(file, "r")) : open(file, "r")
@@ -257,16 +257,16 @@ end
 
 function cut!(read::LongDNASeq, pos::Int; keep=:left, from=:left)
     0 <= pos <= length(read) || resize!(read, 0)
-    
+
     if (from == :left) && (keep == :left)
         resize!(read, pos)
 
     elseif (from == :left) && (keep == :right)
         reverse!(resize!(reverse!(read), length(read)-pos, true))
-    
+
     elseif (from == :right) && (keep == :left)
         resize!(read, length(read)-pos)
-    
+
     elseif (from == :right) && (keep == :right)
         reverse!(resize!(reverse!(read), pos, true))
     end
@@ -357,7 +357,7 @@ end
 function Base.filter!(f, reads::PairedSequences; logic=:or)
     @assert logic in [:or, :xor, :and]
     for (key, (read1, read2)) in reads.dict
-        if logic == :and 
+        if logic == :and
             f(read1) && f(read2) || delete!(reads.dict, key)
         elseif logic == :or
             f(read1) || f(read2) || delete!(reads.dict, key)
@@ -368,7 +368,7 @@ function Base.filter!(f, reads::PairedSequences; logic=:or)
     end
 end
 
-occurences(test_sequence::LongDNASeq, seqs::Sequences{T}, similarity_cut::Float64; score_model=AffineGapScoreModel(match=1, mismatch=-1, gap_open=-1, gap_extend=-1)) where T = 
+occurences(test_sequence::LongDNASeq, seqs::Sequences{T}, similarity_cut::Float64; score_model=AffineGapScoreModel(match=1, mismatch=-1, gap_open=-1, gap_extend=-1)) where T =
     sum(similarity(test_sequence, seq; score_model=score_model) > similarity_cut for seq in seqs)
 
 function similarity(read1::LongDNASeq, read2::LongDNASeq; score_model=nothing)
@@ -392,8 +392,8 @@ function nucleotidecount(reads::Sequences; normalize=true)
     count = Dict(DNA_A => zeros(max_length), DNA_T=>zeros(max_length), DNA_G=>zeros(max_length), DNA_C=>zeros(max_length), DNA_N=>zeros(max_length))
     nb_reads = length(reads)
     for read in reads
-        (align==:left) ? 
-        (index = 1:length(read)) : 
+        (align==:left) ?
+        (index = 1:length(read)) :
         (index = (max_length - length(read) + 1):max_length)
         for (i, n) in zip(index, read)
             count[n][i] += 1
@@ -413,8 +413,8 @@ function nucleotidecount(reads::PairedSequences; normalize=true)
     count2 = Dict(DNA_A => zeros(max_length), DNA_T=>zeros(max_length), DNA_G=>zeros(max_length), DNA_C=>zeros(max_length), DNA_N=>zeros(max_length))
     nb_reads = length(reads)
     for (read1, read2) in reads
-        (align==:left) ? 
-        (index1 = 1:length(read1); index2 = 1:length(read2)) : 
+        (align==:left) ?
+        (index1 = 1:length(read1); index2 = 1:length(read2)) :
         (index1 = (max_length - length(read1) + 1):max_length; index2 = (max_length - length(read2) + 1):max_length)
         for ((i1, n1),(i2, n2)) in zip(zip(index1, read1), zip(index2, read2))
             count1[n1][i1] += 1


### PR DESCRIPTION
Is this method correct? 
`function compute_coverage(files::PairedSingleTypeFiles; ...)`

I only changed files parameters type to PairedSingleTypeFiles.
Do more adaptions need to be done?
